### PR TITLE
Add config to launch test webapp from the command line with Maven. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,22 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.mortbay.jetty</groupId>
+				<artifactId>jetty-maven-plugin</artifactId>
+				<version>8.0.4.v20111024</version>
+				<configuration>
+					<webAppSourceDirectory>src/test/webapp</webAppSourceDirectory>
+					<useTestScope>true</useTestScope>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.tapestry</groupId>
+						<artifactId>tapestry-core</artifactId>
+						<version>${tapestry-release-version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
The webapp is deployed in a jetty container by the jetty maven plugin.
To launch webapp simply type mvn jetty:run.
