### PR TITLE
Specify gmap marker info as a block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 						<configuration>
 							<rules>
 								<requireJavaVersion>
-									<version>[1.5.0,1.6.0)</version>
+									<version>[1.5.0,1.6.1)</version>
 								</requireJavaVersion>
 							</rules>
 							<fail>true</fail>


### PR DESCRIPTION
Hi, further to my conversation with Laurent here http://tapestry.1045711.n5.nabble.com/tml-parameter-rendered-into-a-JavaScript-string-td5512889.html I have added the ability to specify the info for a gmap marker as a block of tml. This is backwards compatible in that info can also be specified as an attribute.

Cheers,
Lance.
